### PR TITLE
sethome: don't re-write file if nothing's changed

### DIFF
--- a/sethome/init.lua
+++ b/sethome/init.lua
@@ -107,6 +107,7 @@ minetest.register_globalstep(function(dtime)
                 output:write(v.x.." "..v.y.." "..v.z.." "..i.."\n")
             end
             io.close(output)
+            changed = false
         end
     end
 end)


### PR DESCRIPTION
previously, the sethome mod would re-write home locations nonstop every
10 seconds, once a single person changed their home location after
server startup.

with this patch, sethome will stop re-writing the file, once changes
have been saved once, and will not continue to do so until another
player changes their home location.
